### PR TITLE
a couple readme additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,14 @@ warOverlay {
 ```
 
 For a sample, see https://github.com/Unicon/unicon-cas-overlay/blob/CAS4/build.gradle
+
+# Troubleshooting
+
+If you include any signed JARs in your WAR, you'll likely encounter signature verification errors at runtime.  To get around this, exclude the signature files from inclusion in your WAR like this:
+
+```groovy
+war {
+    // ... whatever else you may need
+    exclude "META-INF/*.RSA", "META-INF/*.SF", "META-INF/*.DSA"
+}
+```


### PR DESCRIPTION
It looks like the plugin has been added to JCenter.  I've updated the readme to include instructions on how to import the plugin directly using JCenter.  Internally, we use an Artifactory instance that proxies JCenter, but I expect that the organizations that have something like that set up will already be aware of how to configure it.

The one additional gotcha I've encountered with the plugin is with regards to handling signed JARs.  I documented the workaround that we're using in the readme as well.
